### PR TITLE
fix python version

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-urdf-geometry-parser
 	pkgdesc = ROS - Extract geometry value of a vehicle from urdf.
 	pkgver = 0.0.3
-	pkgrel = 3
+	pkgrel = 4
 	url = https://wiki.ros.org/urdf_geometry_parser
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgname='ros-noetic-urdf-geometry-parser'
 pkgver='0.0.3'
 _pkgver_patch=0
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=3
+pkgrel=4
 license=('BSD')
 
 ros_makedepends=(ros-noetic-tf2
@@ -46,7 +46,7 @@ build() {
   cmake ${srcdir}/${_dir} \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
-        -DPYTHON_EXECUTABLE=/usr/bin/python2 \
+        -DPYTHON_EXECUTABLE=/usr/bin/python3 \
         -DSETUPTOOLS_DEB_LAYOUT=OFF
   make
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -46,7 +46,7 @@ build() {
   cmake ${srcdir}/${_dir} \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
-        -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+        -DPYTHON_EXECUTABLE=/usr/bin/python \
         -DSETUPTOOLS_DEB_LAYOUT=OFF
   make
 }


### PR DESCRIPTION
fix:
```
CMake Error at /usr/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find PythonInterp: Found unsuitable version "2.7.18", but
  required is at least "3" (found /usr/bin/python2)
Call Stack (most recent call first):
  /usr/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:575 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.19/Modules/FindPythonInterp.cmake:169 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  /opt/ros/noetic/share/catkin/cmake/python.cmake:4 (find_package)
  /opt/ros/noetic/share/catkin/cmake/all.cmake:164 (include)
  /opt/ros/noetic/share/catkin/cmake/catkinConfig.cmake:20 (include)
  CMakeLists.txt:6 (find_package)
```